### PR TITLE
Modified IDataModel.validate() implementations

### DIFF
--- a/src/main/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/City.java
+++ b/src/main/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/City.java
@@ -38,7 +38,7 @@ public class City extends NumberIdDataModel {
     public void validate() {
         Objects.requireNonNull(getName(), "'name' must not be null.");
         Objects.requireNonNull(getCountry(), "'country' must not be null.");
-        Objects.requireNonNull(getCountryId(), "'country_id' must not be null.");
+        getCountry().validate();
     }
 
     public String getName() {

--- a/src/main/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/Measurement.java
+++ b/src/main/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/Measurement.java
@@ -45,7 +45,7 @@ public class Measurement implements IDataModel<Measurement.MeasurementId> {
     @Override
     public void validate() {
         Objects.requireNonNull(getCity(), "'city' must not be null.");
-        Objects.requireNonNull(getCityId(), "'city' must not be null.");
+        getCity().validate();
         Objects.requireNonNull(getDatetime(), "'datetime' must not be null.");
     }
 


### PR DESCRIPTION
- validate referenced objects
- do not enforce persistence in validation (decoupling