### PR TITLE
In tests, entity dependencies are initialized through DataModelTestData and persisted/reset by DataModelRepositoryTestHelper

### DIFF
--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/CityTestData.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/CityTestData.java
@@ -1,16 +1,22 @@
 package cz.tul.ppj.hynekvaclavsvobodny.sp.data;
 
-import cz.tul.ppj.hynekvaclavsvobodny.sp.repositories.CountryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 @Component
 public class CityTestData extends NumberIdDataModelTestData<City> {
 
+    private final CountryTestData countryTestData;
+
     @Autowired
-    private CountryRepository countryRepository;
+    public CityTestData(CountryTestData countryTestData) {
+        super();
+        this.countryTestData = countryTestData;
+        addDependency(countryTestData);
+    }
 
     @Override
     public City emptyInstance() {
@@ -19,19 +25,35 @@ public class CityTestData extends NumberIdDataModelTestData<City> {
 
     @Override
     public Stream<City> objsValid() {
+        Map<String, Country> countries = countryTestData.getObjsValidByCode();
+
         return Stream.of(
-                new City("Jablonec nad Nisou", countryRepository.getById(1)),
-                new City("Los Angeles", countryRepository.getByCode("US"))
+                // same as in data.sql
+                new City("Liberec", countries.get("CZ")),
+                new City("Praha", countries.get("CZ")),
+                new City("New York", countries.get("US")),
+                new City("London", countries.get("UK")),
+                new City("Berlin", countries.get("DE")),
+
+                // additional
+                new City("Jablonec nad Nisou", countries.get("CZ")),
+                new City("Los Angeles", countries.get("US"))
         );
+    }
+
+    public Map<String, City> getObjsValidByName() {
+        return TestDataUtils.mapByKey(getObjsValid(), City::getName);
     }
 
     @Override
     public Stream<City> objsInvalid() {
+        Map<String, Country> countries = countryTestData.getObjsValidByCode();
+
         return Stream.concat(
                 super.objsInvalid(),
                 Stream.of(
                         new City(null, null),
-                        new City(null, countryRepository.getById(2)),
+                        new City(null, countries.get("CZ")),
                         new City("Unknown",  null)
                 )
         );

--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/CountryTestData.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/CountryTestData.java
@@ -2,6 +2,7 @@ package cz.tul.ppj.hynekvaclavsvobodny.sp.data;
 
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 @Component
@@ -15,9 +16,20 @@ public class CountryTestData extends NumberIdDataModelTestData<Country> {
     @Override
     public Stream<Country> objsValid() {
         return Stream.of(
+                // same as in data.sql
+                new Country("CZ", "Czech Republic"),
+                new Country("US", "United States"),
+                new Country("UK", "United Kingdom"),
+                new Country("DE", "Germany"),
+
+                // additional
                 new Country("AT", "Austria"),
                 new Country("DK", "Denmark")
         );
+    }
+
+    public Map<String,Country> getObjsValidByCode() {
+        return TestDataUtils.mapByKey(getObjsValid(), Country::getCode);
     }
 
     @Override

--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/DataModelTest.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/DataModelTest.java
@@ -1,5 +1,6 @@
 package cz.tul.ppj.hynekvaclavsvobodny.sp.data;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -22,8 +23,13 @@ public abstract class DataModelTest<E extends IDataModel<ID>, T extends DataMode
 
     protected E obj;
 
+    @BeforeAll
+    public void initializeAll() {
+        data.reset();
+    }
+
     @BeforeEach
-    public void initialize() {
+    public void initializeEach() {
         obj = data.emptyInstance();
     }
 

--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/DataModelTestData.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/DataModelTestData.java
@@ -1,14 +1,37 @@
 package cz.tul.ppj.hynekvaclavsvobodny.sp.data;
 
 import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 public abstract class DataModelTestData<E extends IDataModel<ID>, ID extends Serializable> {
+
+    private List<E> objsValidList = null;
+
+    protected List<DataModelTestData<?,?>> dependencies = new LinkedList<>();
+
+    protected void addDependency(DataModelTestData<?,?> dependency) {
+        this.dependencies.add(dependency);
+    }
 
     public abstract E emptyInstance();
 
     public Stream<E> objsValid() {
         return Stream.of();
+    }
+
+    public List<E> getObjsValid() {
+        if (objsValidList == null) {
+            objsValidList = objsValid().toList();
+        }
+
+        return objsValidList;
+    }
+
+    public Map<ID, E> getObjsValidById() {
+        return TestDataUtils.mapByKey(getObjsValid(), E::getId);
     }
 
     public Stream<E> objsInvalid() {
@@ -18,5 +41,17 @@ public abstract class DataModelTestData<E extends IDataModel<ID>, ID extends Ser
     public abstract Stream<ID> idsValid();
 
     public abstract Stream<ID> idsInvalid();
+
+    public void resetDependencies() {
+        for (DataModelTestData<?,?> dependency : dependencies) {
+            dependency.reset();
+        }
+    }
+
+    public void reset() {
+        resetDependencies();
+        objsValidList = null;
+    }
+
 
 }

--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/MeasurementTestData.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/MeasurementTestData.java
@@ -1,17 +1,23 @@
 package cz.tul.ppj.hynekvaclavsvobodny.sp.data;
 
-import cz.tul.ppj.hynekvaclavsvobodny.sp.repositories.CityRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
+import java.util.Map;
 import java.util.stream.Stream;
 
 @Component
 public class MeasurementTestData extends DataModelTestData<Measurement, Measurement.MeasurementId> {
 
+    private final CityTestData cityTestData;
+
     @Autowired
-    CityRepository cityRepository;
+    public MeasurementTestData(CityTestData cityTestData) {
+        super();
+        this.cityTestData = cityTestData;
+        addDependency(cityTestData);
+    }
 
     @Override
     public Measurement emptyInstance() {
@@ -19,9 +25,11 @@ public class MeasurementTestData extends DataModelTestData<Measurement, Measurem
     }
 
     public Measurement getFullInstance() {
+        Map<String, City> cities = cityTestData.getObjsValidByName();
+
         Measurement m = new Measurement();
 
-        m.setCity(cityRepository.getById(1));
+        m.setCity(cities.get("Jablonec nad Nisou"));
         m.setDatetime(Instant.parse("2024-05-21T02:30:25Z"));
 
         m.setTemp(10.05);
@@ -42,16 +50,19 @@ public class MeasurementTestData extends DataModelTestData<Measurement, Measurem
 
     @Override
     public Stream<Measurement> objsValid() {
+        Map<String, City> cities = cityTestData.getObjsValidByName();
 
         return Stream.of(
-                new Measurement(cityRepository.getById(1), Instant.EPOCH),
-                new Measurement(cityRepository.getByName("Liberec"), Instant.parse("2025-01-21T21:40:00Z")),
+                new Measurement(cities.get("Jablonec nad Nisou"), Instant.EPOCH),
+                new Measurement(cities.get("Los Angeles"), Instant.parse("2025-01-21T21:40:00Z")),
                 getFullInstance()
         );
     }
 
     @Override
     public Stream<Measurement> objsInvalid() {
+        Map<String, City> cities = cityTestData.getObjsValidByName();
+
         return Stream.concat(
                 super.objsInvalid(),
                 Stream.of(
@@ -59,15 +70,17 @@ public class MeasurementTestData extends DataModelTestData<Measurement, Measurem
                         new Measurement(null, null),
                         new Measurement(null, Instant.EPOCH),
                         new Measurement(new City(null), Instant.EPOCH),
-                        new Measurement(cityRepository.getById(0), null)
+                        new Measurement(cities.get("Los Angeles"), null)
                 )
         );
     }
 
     @Override
     public Stream<Measurement.MeasurementId> idsValid() {
+        Map<String, City> cities = cityTestData.getObjsValidByName();
+
         return Stream.of(
-                new Measurement.MeasurementId(cityRepository.getById(0), Instant.EPOCH),
+                new Measurement.MeasurementId(cities.get("Jablonec nad Nisou"), Instant.EPOCH),
                 new Measurement.MeasurementId(new City(null), Instant.EPOCH),
                 new Measurement.MeasurementId(null, Instant.EPOCH),
                 new Measurement.MeasurementId(null, null)
@@ -78,5 +91,12 @@ public class MeasurementTestData extends DataModelTestData<Measurement, Measurem
     @Override
     public Stream<Measurement.MeasurementId> idsInvalid() {
         return Stream.of((Measurement.MeasurementId) null);
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+
+        cityTestData.reset();
     }
 }

--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/TestDataUtils.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/data/TestDataUtils.java
@@ -1,0 +1,23 @@
+package cz.tul.ppj.hynekvaclavsvobodny.sp.data;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class TestDataUtils {
+    private TestDataUtils() {}
+
+    public static <T,K> Map<K,T> mapByKey(Stream<T> objs, Function<? super T, ? extends K> keyMapper) {
+        return objs.collect(Collectors.toMap(
+                keyMapper,
+                Function.identity(),
+                (existing, replacement) -> existing
+        ));
+    }
+
+    public static <T,K> Map<K,T> mapByKey(List<T> objs, Function<? super T, ? extends K> keyMapper) {
+        return mapByKey(objs.stream(), keyMapper);
+    }
+}

--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/CityRepositoryTest.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/CityRepositoryTest.java
@@ -3,4 +3,4 @@ package cz.tul.ppj.hynekvaclavsvobodny.sp.repositories;
 import cz.tul.ppj.hynekvaclavsvobodny.sp.data.City;
 import cz.tul.ppj.hynekvaclavsvobodny.sp.data.CityTestData;
 
-public class CityRepositoryTest extends NumberIdDataModelRepositoryTest<CityRepository, City, CityTestData> {}
+public class CityRepositoryTest extends NumberIdDataModelRepositoryTest<CityRepository, City, CityTestData, CityRepositoryTestHelper> {}

--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/CityRepositoryTestHelper.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/CityRepositoryTestHelper.java
@@ -1,0 +1,17 @@
+package cz.tul.ppj.hynekvaclavsvobodny.sp.repositories;
+
+import cz.tul.ppj.hynekvaclavsvobodny.sp.data.City;
+import cz.tul.ppj.hynekvaclavsvobodny.sp.data.CityTestData;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CityRepositoryTestHelper extends NumberIdDataModelRepositoryTestHelper<CityRepository, City, CityTestData> {
+
+    @Autowired
+    public CityRepositoryTestHelper(CountryRepositoryTestHelper countryRepositoryTestHelper) {
+        super();
+        this.addDependency(countryRepositoryTestHelper);
+    }
+
+}

--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/CountryRepositoryTest.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/CountryRepositoryTest.java
@@ -3,4 +3,4 @@ package cz.tul.ppj.hynekvaclavsvobodny.sp.repositories;
 import cz.tul.ppj.hynekvaclavsvobodny.sp.data.Country;
 import cz.tul.ppj.hynekvaclavsvobodny.sp.data.CountryTestData;
 
-public class CountryRepositoryTest extends NumberIdDataModelRepositoryTest<CountryRepository, Country, CountryTestData> {}
+public class CountryRepositoryTest extends NumberIdDataModelRepositoryTest<CountryRepository, Country, CountryTestData, CountryRepositoryTestHelper> {}

--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/CountryRepositoryTestHelper.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/CountryRepositoryTestHelper.java
@@ -1,0 +1,8 @@
+package cz.tul.ppj.hynekvaclavsvobodny.sp.repositories;
+
+import cz.tul.ppj.hynekvaclavsvobodny.sp.data.Country;
+import cz.tul.ppj.hynekvaclavsvobodny.sp.data.CountryTestData;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CountryRepositoryTestHelper extends NumberIdDataModelRepositoryTestHelper<CountryRepository, Country, CountryTestData> {}

--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/DataModelRepositoryTest.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/DataModelRepositoryTest.java
@@ -2,9 +2,7 @@ package cz.tul.ppj.hynekvaclavsvobodny.sp.repositories;
 
 import cz.tul.ppj.hynekvaclavsvobodny.sp.data.DataModelTestData;
 import cz.tul.ppj.hynekvaclavsvobodny.sp.data.IDataModel;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +17,9 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Transactional
-public abstract class DataModelRepositoryTest<R extends DataModelRepository<E, ID>, E extends IDataModel<ID>, ID extends Serializable, T extends DataModelTestData<E, ID>> {
+public abstract class DataModelRepositoryTest<
+        R extends DataModelRepository<E, ID>, E extends IDataModel<ID>, ID extends Serializable, T extends DataModelTestData<E, ID>, S extends DataModelRepositoryTestHelper<R,E,T>
+    > {
 
     protected E obj;
 
@@ -29,9 +29,23 @@ public abstract class DataModelRepositoryTest<R extends DataModelRepository<E, I
     @Autowired
     protected R repository;
 
+    @Autowired
+    protected S helper;
+
+    @BeforeAll
+    public void initializeAll() {
+        data.reset();
+        helper.persist();
+    }
+
     @BeforeEach
-    public void initialize() {
+    public void initializeEach() {
         obj = data.emptyInstance();
+    }
+
+    @AfterAll
+    public void deinitializeAll() {
+        helper.reset();
     }
 
     @Test

--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/DataModelRepositoryTestHelper.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/DataModelRepositoryTestHelper.java
@@ -1,0 +1,54 @@
+package cz.tul.ppj.hynekvaclavsvobodny.sp.repositories;
+
+import cz.tul.ppj.hynekvaclavsvobodny.sp.data.DataModelTestData;
+import cz.tul.ppj.hynekvaclavsvobodny.sp.data.IDataModel;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class DataModelRepositoryTestHelper<R extends DataModelRepository<E, ?>, E extends IDataModel<?>, T extends DataModelTestData<E, ?>> {
+
+    @Autowired
+    protected R repository;
+
+    @Autowired
+    protected T testData;
+
+    protected List<DataModelRepositoryTestHelper<?,?,?>> dependencies = new LinkedList<>();
+
+    protected void addDependency(DataModelRepositoryTestHelper<?,?,?> dependency) {
+        this.dependencies.add(dependency);
+    }
+
+    public void persist() {
+        for (DataModelRepositoryTestHelper<?, ?, ?> dependency : dependencies) {
+            dependency.persistData();
+        }
+    }
+
+    public void persistSelf() {
+        repository.saveAll(testData.getObjsValid());
+    }
+
+    public void persistData() {
+        persist();
+        persistSelf();
+    }
+
+    public void resetDependencies() {
+        for (DataModelRepositoryTestHelper<?, ?, ?> dependency : dependencies) {
+            dependency.reset();
+        }
+    }
+
+    public void resetSelf() {
+        repository.deleteAll();
+    }
+
+    public void reset() {
+        resetSelf();
+        resetDependencies();
+    }
+
+}

--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/MeasurementRepositoryTest.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/MeasurementRepositoryTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class MeasurementRepositoryTest extends DataModelRepositoryTest<MeasurementRepository, Measurement, Measurement.MeasurementId, MeasurementTestData> {
+public class MeasurementRepositoryTest extends DataModelRepositoryTest<MeasurementRepository, Measurement, Measurement.MeasurementId, MeasurementTestData, MeasurementRepositoryTestHelper> {
 
     @ParameterizedTest
     @MethodSource("objsValid")

--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/MeasurementRepositoryTestHelper.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/MeasurementRepositoryTestHelper.java
@@ -1,0 +1,17 @@
+package cz.tul.ppj.hynekvaclavsvobodny.sp.repositories;
+
+import cz.tul.ppj.hynekvaclavsvobodny.sp.data.Measurement;
+import cz.tul.ppj.hynekvaclavsvobodny.sp.data.MeasurementTestData;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MeasurementRepositoryTestHelper extends DataModelRepositoryTestHelper<MeasurementRepository, Measurement, MeasurementTestData> {
+
+    @Autowired
+    public MeasurementRepositoryTestHelper(CityRepositoryTestHelper cityRepositoryTestHelper) {
+        super();
+        this.addDependency(cityRepositoryTestHelper);
+    }
+
+}

--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/NumberIdDataModelRepositoryTest.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/NumberIdDataModelRepositoryTest.java
@@ -12,8 +12,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 public abstract class NumberIdDataModelRepositoryTest<
-        R extends NumberIdDataModelRepository<E>, E extends NumberIdDataModel, T extends NumberIdDataModelTestData<E>
-        >  extends DataModelRepositoryTest<R, E, Integer, T> {
+            R extends NumberIdDataModelRepository<E>, E extends NumberIdDataModel, T extends NumberIdDataModelTestData<E>, S extends NumberIdDataModelRepositoryTestHelper<R,E,T>
+        >  extends DataModelRepositoryTest<R, E, Integer, T, S> {
 
     @ParameterizedTest
     @MethodSource("objsValid")

--- a/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/NumberIdDataModelRepositoryTestHelper.java
+++ b/src/test/java/cz/tul/ppj/hynekvaclavsvobodny/sp/repositories/NumberIdDataModelRepositoryTestHelper.java
@@ -1,0 +1,7 @@
+package cz.tul.ppj.hynekvaclavsvobodny.sp.repositories;
+
+import cz.tul.ppj.hynekvaclavsvobodny.sp.data.NumberIdDataModel;
+import cz.tul.ppj.hynekvaclavsvobodny.sp.data.NumberIdDataModelTestData;
+
+public class NumberIdDataModelRepositoryTestHelper<R extends NumberIdDataModelRepository<E>, E extends NumberIdDataModel, T extends NumberIdDataModelTestData<E>>
+        extends DataModelRepositoryTestHelper<R,E,T> {}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -2,4 +2,4 @@
 spring.datasource.driver-class-name=org.hsqldb.jdbc.JDBCDriver
 spring.datasource.url=jdbc:hsqldb:mem:testdb
 spring.sql.init.platform=hsqldb
-spring.sql.init.mode=always
+spring.sql.init.mode=never


### PR DESCRIPTION
This ensures the tests are not dependent on data in SQL, achieving independence on repositories in DataModelTest, while allowing to persist/reset for DataModelRepositoryTest.